### PR TITLE
Fix unwanted spelling of message when entering interaction mode.

### DIFF
--- a/addon/globalPlugins/MathMlReader/__init__.py
+++ b/addon/globalPlugins/MathMlReader/__init__.py
@@ -240,7 +240,7 @@ class MathMlReaderInteraction(mathPres.MathInteractionNVDAObject):
 		return MathMlTextInfo(self, position)
 
 	def event_gainFocus(self):
-		speech.speak(_("enter interaction mode"))
+		speech.speak([_("enter interaction mode")])
 		super(MathMlReaderInteraction, self).event_gainFocus()
 		api.setReviewPosition(self.makeTextInfo(), False)
 


### PR DESCRIPTION
Issue:
When entering in interaction mode, the message "enter interaction mode" is spellt, whereas it should be spoken normally.

Cause:
The message string is passed directly to speech.speak. However speech.speak expects a commands sequence. Thus each character of the string is considered a part of the sequence, thus spellt.

Solution:
Add bracket around the string in order to pass a list of one string to speech.speak.

Notes:
Another solution would be to use speech.speakMessage. However I have kept speech.speak with the string list in order to conform to other spoken messages in this addon.
