### PR TITLE
Add rule for single-symbol vector in French notation (arrow above sym…

### DIFF
--- a/addon/globalPlugins/MathMlReader/A8M_PM.py
+++ b/addon/globalPlugins/MathMlReader/A8M_PM.py
@@ -852,10 +852,13 @@ class LineSegmentType(NonTerminalNodeType):
 	child = [TwoMiOperandItemType, MoLineSegmentType]
 	name = 'LineSegmentType'
 
+#Arrow above 2 symbols denotes Ray in English notation and vector in French notation (equivalent of VectorDoubleType).
+#Arrow above 1 symbol denotes also vector in French notation.
 class MoRayType(TerminalNodeType):
 	tag = Mo
 	data = re.compile(ur"^[→]$")
 
+#Arrow above 2 symbols denotes Ray in English notation and vector in French notation (equivalent of VectorDoubleType).
 class RayType(NonTerminalNodeType):
 	tag = Mover
 	child = [TwoMiOperandItemType, MoRayType]
@@ -874,6 +877,12 @@ class VectorDoubleType(NonTerminalNodeType):
 	tag = Mover
 	child = [TwoMiOperandItemType, MoVectorType]
 	name = 'VectorDoubleType'
+
+#Arrow above single symbol denotes vector in French notation.
+class ArrowOverSingleSymbolType(NonTerminalNodeType):
+	tag = Mover
+	child = [MiOperandType, MoRayType]
+	name = 'ArrowOverSingleSymbolType'
 
 class MoFrownType(TerminalNodeType):
 	tag = Mo
@@ -1294,6 +1303,7 @@ mathrule_info = {
 		"LineSegmentType": [3, 2, ".",],
 		"VectorSingleType": [3, 2, ".",],
 		"VectorDoubleType": [3, 2, ".",],
+		"ArrowOverSingleSymbolType": [3, 2, ".",],
 		"FrownType": [3, 2, ".",],
 	},
 	"other": {
@@ -1375,6 +1385,7 @@ mathrule_order = {
 		"LineSegmentType",
 		"VectorSingleType",
 		"VectorDoubleType",
+		"ArrowOverSingleSymbolType",
 		"FrownType",
 	],
 	"other": [

--- a/addon/globalPlugins/MathMlReader/locale/en/math.rule
+++ b/addon/globalPlugins/MathMlReader/locale/en/math.rule
@@ -43,4 +43,5 @@ RayType	ray, 0,	main,super	ray
 LineSegmentType	line segment, 0,	main,super	line segment
 VectorSingleType	vector, 0,	main,super	vector have one symbol
 VectorDoubleType	vector, 0,	main,super	vector have two symbol
+ArrowOverSingleSymbolType	vector, 0,	main,super	Arrow over a single symbol (vector in French notation)
 FrownType	frown, 0,	main,super	frown

--- a/addon/globalPlugins/MathMlReader/locale/fr/math.rule
+++ b/addon/globalPlugins/MathMlReader/locale/fr/math.rule
@@ -39,8 +39,9 @@ PositiveSignType	positif,	plus	signe positif
 SquarePowerType	, 0, au carré	base,exposant	élévation au carré
 CubePowerType	, 0, au cube	base,exposant	élévation au cube
 LineType	droite, 0,	principal,suscrit	droite (notation anglo-saxonne)
-RayType	vecteur, 0,	principal,suscrit	vecteur (notation française) = demi-droite (notation anglo-saxonne)
+RayType	vecteur, 0,	principal,suscrit	vecteur avec deux symboles (notation française) = demi-droite (notation anglo-saxonne)
 LineSegmentType	mesure algébrique de, 0,	principal,suscrit	mesure algébrique (notation française) = segment (notation anglo-saxonne)
 VectorSingleType	vecteur, 0,	principal,suscrit	vecteur avec un symbole (notation anglo-saxonne)
 VectorDoubleType	vecteur, 0,	principal,suscrit	vecteur avec deux symboles (notation anglo-saxonne)
+ArrowOverSingleSymbolType	vecteur, 0,	main,super	Vecteur avec un symbole (notation française)
 FrownType	arc, 0,	principal,suscrit	arc

--- a/addon/globalPlugins/MathMlReader/locale/tr/math.rule
+++ b/addon/globalPlugins/MathMlReader/locale/tr/math.rule
@@ -43,3 +43,4 @@ set	küme, (.*), küme sonu	eleman	set
 single_fraction	, , 0, bölü, 1, , 	pay, payda	single fraction
 single_square_root	kare kök, 0, 	kök içi	single square root
 to	operator, 0, to, 1, apply to	operator, to	to ... operator
+ArrowOverSingleSymbolType	vector, 0,	main,super	Arrow over a single symbol (vector in French notation)

--- a/addon/globalPlugins/MathMlReader/locale/zh_CN/math.rule
+++ b/addon/globalPlugins/MathMlReader/locale/zh_CN/math.rule
@@ -43,4 +43,5 @@ RayType	射线, 0,	主符号,正上标	射线
 LineSegmentType	线段, 0,	主符号,正上标	线段
 VectorSingleType	向量, 0,	主符号,正上标	单符号向量
 VectorDoubleType	向量, 0,	主符号,正上标	双符号向量
+ArrowOverSingleSymbolType	vector, 0,	main,super	Arrow over a single symbol (vector in French notation)
 FrownType	弧, 0,	主符号,正上标	符号弧

--- a/addon/globalPlugins/MathMlReader/locale/zh_TW/math.rule
+++ b/addon/globalPlugins/MathMlReader/locale/zh_TW/math.rule
@@ -43,4 +43,5 @@ RayType	射線, 0,	主符號,正上標	射線
 LineSegmentType	線段, 0,	主符號,正上標	線段
 VectorSingleType	向量, 0,	主符號,正上標	單符號向量
 VectorDoubleType	向量, 0,	主符號,正上標	雙符號向量
+ArrowOverSingleSymbolType	vector, 0,	main,super	Arrow over a single symbol (vector in French notation)
 FrownType	弧, 0,	主符號,正上標	符號弧

--- a/addon/globalPlugins/MathMlReader/math.example
+++ b/addon/globalPlugins/MathMlReader/math.example
@@ -37,6 +37,7 @@ RayType	<math><mrow><mover accent='true'><mrow><mi>A</mi><mi>B</mi></mrow><mo st
 LineSegmentType	<math><mover><mrow><mi>A</mi><mi>B</mi></mrow><mo>&#xAF;</mo></mover></math>
 VectorSingleType	<math><mrow><mover accent='true'><mrow><mi>A</mi></mrow><mo stretchy='true'>&#x21C0;</mo></mover></mrow></math>
 VectorDoubleType	<math><mrow><mover accent='true'><mrow><mi>A</mi><mi>B</mi></mrow><mo stretchy='true'>&#x21C0;</mo></mover></mrow></math>
+ArrowOverSingleSymbolType	<math><mrow><mover accent='true'><mrow><mi>a</mi></mrow><mo stretchy='true'>&#x2192;</mo></mover></mrow></math>
 FrownType	<math><mrow><mover accent='true'><mrow><mi>A</mi><mi>B</mi></mrow><mo stretchy='true'>&#x2322;</mo></mover></mrow></math>
 NegativeSignType	<math><mo>-</mo><mn>2</mn></math>
 PositiveSignType	<math><mo>+</mo><mn>2</mn></math>

--- a/addon/globalPlugins/MathMlReader/math.rule
+++ b/addon/globalPlugins/MathMlReader/math.rule
@@ -43,4 +43,5 @@ RayType	ray, 0,	main,super	ray
 LineSegmentType	line segment, 0,	main,super	line segment
 VectorSingleType	vector, 0,	main,super	vector have one symbol
 VectorDoubleType	vector, 0,	main,super	vector have two symbol
+ArrowOverSingleSymbolType	vector, 0,	main,super	Arrow over a single symbol (vector in French notation)
 FrownType	frown, 0,	main,super	frown


### PR DESCRIPTION
Hello Woody

Here is the PR for French single-symbol notation.
Translators (tr, zh_CN, zh_TW) will have to translate the rule that is in English in their math.rule file.

Regards,

Cyrille