### PR TITLE
Adding an option to omit speaking item numbers

### DIFF
--- a/addon/globalPlugins/MathMlReader/__init__.py
+++ b/addon/globalPlugins/MathMlReader/__init__.py
@@ -346,13 +346,14 @@ class MathMlReaderInteraction(mathPres.MathInteractionNVDAObject):
 
 		if r:
 			api.setReviewPosition(self.makeTextInfo(), False)
-			if self.mathcontent.pointer.parent:
-				if convert_bool(os.environ['AG']) and self.mathcontent.pointer.parent.role_level == A8M_PM.AUTO_GENERATE:
+			if convert_bool(os.environ['AI']):
+				if self.mathcontent.pointer.parent:
+					if convert_bool(os.environ['AG']) and self.mathcontent.pointer.parent.role_level == A8M_PM.AUTO_GENERATE:
+						speech.speak([self.mathcontent.pointer.des])
+					elif convert_bool(os.environ['DG']) and self.mathcontent.pointer.parent.role_level == A8M_PM.DIC_GENERATE:
+						speech.speak([self.mathcontent.pointer.des])
+				else:
 					speech.speak([self.mathcontent.pointer.des])
-				elif convert_bool(os.environ['DG']) and self.mathcontent.pointer.parent.role_level == A8M_PM.DIC_GENERATE:
-					speech.speak([self.mathcontent.pointer.des])
-			else:
-				speech.speak([self.mathcontent.pointer.des])
 			speech.speak(translate_SpeechCommand(self.mathcontent.pointer.serialized()))
 		else:
 			speech.speak([_("not move")])

--- a/addon/globalPlugins/MathMlReader/configure.py
+++ b/addon/globalPlugins/MathMlReader/configure.py
@@ -13,6 +13,7 @@ settings = [
 	"AMM",
 	"DG",
 	"AG",
+	"AI",
 	"SingleMsubsupType",
 	"SingleMsubType",
 	"SingleMsupType",

--- a/addon/globalPlugins/MathMlReader/dialogs.py
+++ b/addon/globalPlugins/MathMlReader/dialogs.py
@@ -44,6 +44,7 @@ class GeneralSettingsDialog(SettingsDialog):
 		("AMM", _("Analyze mathematical meaning of content")),
 		("DG", _("Read defined meaning in dictionary")),
 		("AG", _("Read of auto-generated meaning")),
+		("AI", _("Announce index of items in current frame")),
 	])
 
 	def makeSettings(self, settingsSizer):


### PR DESCRIPTION
Hi, thanks for great add-on, I use it very often! I propose to add an option to omit saying item numbers, like item 1, item2, because I find it distracting when reading large formulas. I call the option "Speak item numbers" and it is enabled by default, so existing users' experience won't be affected. Thanks!