### PR TITLE
Fix translatable string bug for Shortcut gestures deactivate

### DIFF
--- a/addon/globalPlugins/Access8Math/writer.py
+++ b/addon/globalPlugins/Access8Math/writer.py
@@ -307,7 +307,7 @@ class TextMathEditField(NVDAObject):
 		else:
 			shortcut_mode = not shortcut_mode
 			self.unbindShortcutGestures()
-			ui.message(_("Shortcut gestures activated"))
+			ui.message(_("Shortcut gestures deactivated"))
 
 	@script(
 		gestures=["kb:nvda+alt+g"],


### PR DESCRIPTION
Hi,
Line 310 should be changed to: ```ui.message(_("Shortcut gestures deactivated"))```
