### PR TITLE
Remove panel in NVDA's settings since there is now a specific A8M setting window

### DIFF
--- a/addon/globalPlugins/Access8Math/__init__.py
+++ b/addon/globalPlugins/Access8Math/__init__.py
@@ -193,7 +193,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 		self.language = config.conf["Access8Math"]["settings"]["language"]
 		self.create_menu()
-		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.append(MathReaderSettingsPanel)
 
 	def terminate(self):
 		from lib.latex import latexData


### PR DESCRIPTION
### Issue
* In NVDA multi-category settings window, there is a Math reader panel.
* If you reload the plugins with NVDA+ctrl+F3, you even have one more panel in this window each time you reload the plugins.
* Moreover, A8M has now its own multi-category settings window with already a math reader panel
### Solution
Removed the Math reader panel which seems to have been forgotten in NVDA settings window.
