### PR TITLE
Fix logged error when locking up the computer

### DIFF
--- a/addon/globalPlugins/Access8Math/__init__.py
+++ b/addon/globalPlugins/Access8Math/__init__.py
@@ -201,9 +201,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(MathReaderSettingsPanel)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if obj.windowClassName == "wxWindowNR" and obj.role == ROLE_WINDOW and obj.name == _("Access8Math interaction window"):
+		if getattr(obj, 'windowClassName', None) == "wxWindowNR" and obj.role == ROLE_WINDOW and obj.name == _("Access8Math interaction window"):
 			clsList.insert(0, AppWindowRoot)
-		if obj.windowClassName == "Edit" and obj.role == ROLE_EDITABLETEXT:
+		if getattr(obj, 'windowClassName', None) == "Edit" and obj.role == ROLE_EDITABLETEXT:
 			clsList.insert(0, TextMathEditField)
 
 	def create_menu(self):


### PR DESCRIPTION
Hi Woody

Here is a PR fixing a a little issue; there is no functional issue though.

### Issue
When locking the computer (`Windows+l`)or switching to a secure screen, an error message is logged:
```
ERROR - NVDAObjects.__call__ (11:30:31.558) - MainThread (8364):
Exception in chooseNVDAObjectOverlayClasses for GlobalPlugin ('globalPlugins.Access8Math')
Traceback (most recent call last):
  File "NVDAObjects\__init__.pyc", line 118, in __call__
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\Access8Math\globalPlugins\Access8Math\__init__.py", line 204, in chooseNVDAObjectOverlayClasses
    if obj.windowClassName == "wxWindowNR" and obj.role == ROLE_WINDOW and obj.name == _("Access8Math interaction window"):
       ^^^^^^^^^^^^^^^^^^^
AttributeError: '_SecureDesktopNVDAObject' object has no attribute 'windowClassName'
```
The error is due to the fact that not all `NVDAObject`'s are `Window` objects and thus, not all have a `windowClassName` attribute. More specifically, the secure screen object is not an object corresponding to a real window.

This error does not cause functional issue but having error that should be ignored in the log is disturbing when performing other debug tasks.

### Solution
Try to get the `windowClassName` attribute and return `None` if it is missing.



### 