### PR TITLE
Fix error in chooseNVDAObjectOverlayClasses

### DIFF
--- a/addon/globalPlugins/Access8Math/__init__.py
+++ b/addon/globalPlugins/Access8Math/__init__.py
@@ -253,13 +253,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		gui.settingsDialogs.NVDASettingsDialog.categoryClasses.remove(MathReaderSettingsPanel)
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
-		if obj.windowClassName == "wxWindowNR" and obj.role == ROLE_WINDOW and obj.name == _("Access8Math interaction window"):
+		if getattr(obj, 'windowClassName', None) == "wxWindowNR" and obj.role == ROLE_WINDOW and obj.name == _("Access8Math interaction window"):
 			clsList.insert(0, AppWindowRoot)
-		elif obj.windowClassName == "Edit" and obj.role == ROLE_EDITABLETEXT:
+		elif getattr(obj, 'windowClassName', None) == "Edit" and obj.role == ROLE_EDITABLETEXT:
 			try:
 				if _("Access8Math Editor") in obj.parent.parent.name or obj.appModule.appName.startswith("notepad"):
 					clsList.insert(0, TextMathEditField)
-			except AttributeError:
+			except (AttributeError, TypeError):
 				pass
 
 		try:


### PR DESCRIPTION
### Issue
In A8M 4.1.1 with NVDA 2024.2, there are two errors in `chooseNVDAObjectOverlayClasses`:

#### Error 1: in 6pad++ editor's edit field

```
ERROR - NVDAObjects.__call__ (11:34:02.700) - MainThread (1600):
Exception in chooseNVDAObjectOverlayClasses for GlobalPlugin ('globalPlugins.Access8Math')
Traceback (most recent call last):
  File "NVDAObjects\__init__.pyc", line 118, in __call__
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\Access8Math\globalPlugins\Access8Math\__init__.py", line 260, in chooseNVDAObjectOverlayClasses
    if _("Access8Math Editor") in obj.parent.parent.name or obj.appModule.appName.startswith("notepad"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

This error occurs because `obj.parent.parent.name` is `None`

#### Error 2: When locking the computer pressing `windows+L`

```
ERROR - NVDAObjects.__call__ (11:30:04.212) - MainThread (1600):
Exception in chooseNVDAObjectOverlayClasses for GlobalPlugin ('globalPlugins.Access8Math')
Traceback (most recent call last):
  File "NVDAObjects\__init__.pyc", line 118, in __call__
  File "C:\Users\Cyrille\AppData\Roaming\nvda\addons\Access8Math\globalPlugins\Access8Math\__init__.py", line 256, in chooseNVDAObjectOverlayClasses
    if obj.windowClassName == "wxWindowNR" and obj.role == ROLE_WINDOW and obj.name == _("Access8Math interaction window"):
       ^^^^^^^^^^^^^^^^^^^
AttributeError: '_SecureDesktopNVDAObject' object has no attribute 'windowClassName'
```

This error occurs because not all `NVDAObject`s have an attribute `windowClassName`; only the ones constructed from a real window (`NVDAObjects.window.Window`) which are the vast majority have.

Please remember this; I think I had already fixed such an issue in the past.

### Fixes
#### Error 1
Also filter on Type`Error` in the except clause

#### Error 2:
Instead of `obj.windowClassName`, use `getattr(obj, 'windowClassName', None)` instead. This allows to return `None` when the attribute does not exist rather than raising `AttributeError` exception.


