### PR TITLE
Fix braille support when braille table = auto

### DIFF
--- a/addon/globalPlugins/Access8Math/lib/mathProcess.py
+++ b/addon/globalPlugins/Access8Math/lib/mathProcess.py
@@ -80,8 +80,13 @@ def asciimath2latex(data):
 def nemeth2latex(data):
 	BRAILLE_UNICODE_PATTERNS_START = 0x2800
 	temp = ""
+	confBrailleTable = config.conf["braille"]["translationTable"]
+	if confBrailleTable == "auto":
+		brailleTableFile = brailleTables.getDefaultTableForCurLang(brailleTables.TableType.OUTPUT)
+	else:
+		brailleTableFile = confBrailleTable
 	for string in data:
-		brailleCells, brailleToRawPos, rawToBraillePos, brailleCursorPos = louisHelper.translate([os.path.join(brailleTables.TABLES_DIR, config.conf["braille"]["translationTable"]), "braille-patterns.cti"], string, mode=4)
+		brailleCells, brailleToRawPos, rawToBraillePos, brailleCursorPos = louisHelper.translate([os.path.join(brailleTables.TABLES_DIR, brailleTableFile), "braille-patterns.cti"], string, mode=4)
 		temp += "".join([chr(BRAILLE_UNICODE_PATTERNS_START + cell) for cell in brailleCells])
 	data = "".join(temp)
 

--- a/addon/globalPlugins/Access8Math/output.py
+++ b/addon/globalPlugins/Access8Math/output.py
@@ -157,8 +157,13 @@ def translate_Braille(serializes):
 	@rtype str
 	"""
 	temp = ''
+	confBrailleTable = config.conf["braille"]["translationTable"]
+	if confBrailleTable == "auto":
+		brailleTableFile = brailleTables.getDefaultTableForCurLang(brailleTables.TableType.OUTPUT)
+	else:
+		brailleTableFile = confBrailleTable
 	for string in flatten(serializes):
-		brailleCells, brailleToRawPos, rawToBraillePos, brailleCursorPos = louisHelper.translate([os.path.join(brailleTables.TABLES_DIR, config.conf["braille"]["translationTable"]), "braille-patterns.cti"], string, mode=4)
+		brailleCells, brailleToRawPos, rawToBraillePos, brailleCursorPos = louisHelper.translate([os.path.join(brailleTables.TABLES_DIR, brailleTableFile), "braille-patterns.cti"], string, mode=4)
 		temp += "".join([chr(BRAILLE_UNICODE_PATTERNS_START + cell) for cell in brailleCells])
 	return "".join(temp)
 


### PR DESCRIPTION
### Issue
From 2025.1 onwards, braille table can be set to "auto" in NVDA's config  (see #17222).
This was not handled in this add-on's code, causing error when translating math to braille.

The following error is logged:
```
ERROR - scriptHandler.executeScript (16:03:15.211) - MainThread (21428):
error executing script: <bound method A8MInteraction.script_navigate of <globalPlugins.Access8Math.interaction.A8MInteraction object at 0x09ACC190>> with gesture 'flèche bas'
Traceback (most recent call last):
  File "scriptHandler.pyc", line 300, in executeScript
  File "C:\Users\CB232690\AppData\Roaming\nvda\addons\Access8Math\globalPlugins\Access8Math\interaction.py", line 326, in script_navigate
    cells = translate_Braille(self.mathcontent.pointer.brailleserialized())
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\CB232690\AppData\Roaming\nvda\addons\Access8Math\globalPlugins\Access8Math\output.py", line 160, in translate_Braille
    brailleCells, brailleToRawPos, rawToBraillePos, brailleCursorPos = louisHelper.translate([os.path.join(brailleTables.TABLES_DIR, config.conf["braille"]["translationTable"]), "braille-patterns.cti"], string, mode=4)
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "louisHelper.pyc", line 155, in translate
  File "louis\__init__.pyc", line 266, in translate
RuntimeError: Can't translate: tables ['C:\\Program Files (x86)\\NVDA\\louis\\tables\\auto', 'braille-patterns.cti'], inbuf b'a\x00\x00\x00', typeform None, cursorPos c_long(0), mode 4

```

### Fix
Check if braille table is "auto". If yes, get the default braille table for this language.

### Test
Tested in a formula written in ChatGPT or Wikipedia (with Chrome)

### Additional note
@tsengwoody I have modified in 2 places, but do not exactly which one is used/tested when reading a formula in my browser. Could you test both case or tell me where to test?
